### PR TITLE
Graph traversal

### DIFF
--- a/Tesseract.xcodeproj/project.pbxproj
+++ b/Tesseract.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		D4B5640A1A4CEF2E00795949 /* Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B564091A4CEF2E00795949 /* Assertions.swift */; };
 		D4B5DE341A4F9527004B4C0C /* TermTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B5DE331A4F9526004B4C0C /* TermTests.swift */; };
 		D4B5DE361A505F66004B4C0C /* Graph.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B5DE351A505F66004B4C0C /* Graph.swift */; };
+		D4B695441A7330D200619555 /* Dictionary+HigherOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B695431A7330D200619555 /* Dictionary+HigherOrder.swift */; };
 		D4B7EE6C1A465926006D44E9 /* TypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B7EE6B1A465926006D44E9 /* TypeTests.swift */; };
 		D4B7EE701A466104006D44E9 /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4B7EE6F1A466104006D44E9 /* Either.framework */; };
 		D4B7EE721A46614C006D44E9 /* Prelude.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4B7EE711A46614C006D44E9 /* Prelude.framework */; };
@@ -47,6 +48,7 @@
 		D4B564091A4CEF2E00795949 /* Assertions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assertions.swift; sourceTree = "<group>"; };
 		D4B5DE331A4F9526004B4C0C /* TermTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermTests.swift; sourceTree = "<group>"; };
 		D4B5DE351A505F66004B4C0C /* Graph.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.swift; sourceTree = "<group>"; };
+		D4B695431A7330D200619555 /* Dictionary+HigherOrder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+HigherOrder.swift"; sourceTree = "<group>"; };
 		D4B7EE6B1A465926006D44E9 /* TypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeTests.swift; sourceTree = "<group>"; };
 		D4B7EE6F1A466104006D44E9 /* Either.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Either.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4B7EE711A46614C006D44E9 /* Prelude.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -131,6 +133,7 @@
 			isa = PBXGroup;
 			children = (
 				D4ED827B1A3F9ADB00D0479E /* Info.plist */,
+				D4B695431A7330D200619555 /* Dictionary+HigherOrder.swift */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -269,6 +272,7 @@
 				D4ED829B1A3F9C4900D0479E /* Type.swift in Sources */,
 				D4F5A8CE1A520E7F0058EFDC /* Identifier.swift in Sources */,
 				D4B5DE361A505F66004B4C0C /* Graph.swift in Sources */,
+				D4B695441A7330D200619555 /* Dictionary+HigherOrder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tesseract/Dictionary+HigherOrder.swift
+++ b/Tesseract/Dictionary+HigherOrder.swift
@@ -22,3 +22,13 @@ extension Dictionary {
 		return Swift.reduce(self, initial, combine)
 	}
 }
+
+
+func + <Key: Hashable, Value, S: SequenceType where S.Generator.Element == Dictionary<Key, Value>.Element> (var left: Dictionary<Key, Value>, right: S) -> Dictionary<Key, Value> {
+	var generator = right.generate()
+	let next: () -> (Key, Value)? = { generator.next() }
+	for (key, value) in GeneratorOf(next) {
+		left.updateValue(value, forKey: key)
+	}
+	return left
+}

--- a/Tesseract/Dictionary+HigherOrder.swift
+++ b/Tesseract/Dictionary+HigherOrder.swift
@@ -1,0 +1,16 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+extension Dictionary {
+	init<S: SequenceType where S.Generator.Element == Element>(_ elements: S) {
+		self.init()
+		var generator = elements.generate()
+		let next: () -> Element? = { generator.next() }
+		for (key, value) in GeneratorOf(next) {
+			updateValue(value, forKey: key)
+		}
+	}
+
+	func filter(includeKeyAndValue: Element -> Bool) -> Dictionary {
+		return Dictionary(Swift.filter(self, includeKeyAndValue))
+	}
+}

--- a/Tesseract/Dictionary+HigherOrder.swift
+++ b/Tesseract/Dictionary+HigherOrder.swift
@@ -11,7 +11,7 @@ extension Dictionary {
 	}
 
 	func filter(includeKeyAndValue: Element -> Bool) -> Dictionary {
-		return Dictionary(Swift.filter(self, includeKeyAndValue))
+		return Dictionary(lazy(self).filter(includeKeyAndValue))
 	}
 
 	func map<MappedKey: Hashable, MappedValue>(f: Element -> (MappedKey, MappedValue)) -> Dictionary<MappedKey, MappedValue> {

--- a/Tesseract/Dictionary+HigherOrder.swift
+++ b/Tesseract/Dictionary+HigherOrder.swift
@@ -13,4 +13,8 @@ extension Dictionary {
 	func filter(includeKeyAndValue: Element -> Bool) -> Dictionary {
 		return Dictionary(Swift.filter(self, includeKeyAndValue))
 	}
+
+	func map<MappedKey: Hashable, MappedValue>(f: Element -> (MappedKey, MappedValue)) -> Dictionary<MappedKey, MappedValue> {
+		return Dictionary<MappedKey, MappedValue>(Swift.map(self, f))
+	}
 }

--- a/Tesseract/Dictionary+HigherOrder.swift
+++ b/Tesseract/Dictionary+HigherOrder.swift
@@ -18,6 +18,12 @@ extension Dictionary {
 		return Dictionary<K, V>(lazy(self).map(transform))
 	}
 
+	func flatMap<K: Hashable, V, S: SequenceType where S.Generator.Element == Dictionary<K, V>.Element>(transform: Element -> S) -> Dictionary<K, V> {
+		return reduce(Dictionary<K, V>(minimumCapacity: count)) {
+			$0 + transform($1)
+		}
+	}
+
 	func reduce<Into>(initial: Into, combine: (Into, Element) -> Into) -> Into {
 		return Swift.reduce(self, initial, combine)
 	}

--- a/Tesseract/Dictionary+HigherOrder.swift
+++ b/Tesseract/Dictionary+HigherOrder.swift
@@ -17,4 +17,8 @@ extension Dictionary {
 	func map<K: Hashable, V>(transform: Element -> (K, V)) -> Dictionary<K, V> {
 		return Dictionary<K, V>(lazy(self).map(transform))
 	}
+
+	func reduce<Into>(initial: Into, combine: (Into, Element) -> Into) -> Into {
+		return Swift.reduce(self, initial, combine)
+	}
 }

--- a/Tesseract/Dictionary+HigherOrder.swift
+++ b/Tesseract/Dictionary+HigherOrder.swift
@@ -14,7 +14,7 @@ extension Dictionary {
 		return Dictionary(lazy(self).filter(includeKeyAndValue))
 	}
 
-	func map<MappedKey: Hashable, MappedValue>(f: Element -> (MappedKey, MappedValue)) -> Dictionary<MappedKey, MappedValue> {
-		return Dictionary<MappedKey, MappedValue>(Swift.map(self, f))
+	func map<K: Hashable, V>(transform: Element -> (K, V)) -> Dictionary<K, V> {
+		return Dictionary<K, V>(lazy(self).map(transform))
 	}
 }

--- a/Tesseract/Graph.swift
+++ b/Tesseract/Graph.swift
@@ -51,6 +51,29 @@ public struct Graph<T> {
 			}
 		}
 	}
+
+	
+	// MARK: Higher-order methods.
+
+	public func filter(includeNode: (Identifier, T) -> Bool) -> Graph {
+		return Graph(nodes: nodes.filter(includeNode), edges: edges)
+	}
+}
+
+
+extension Dictionary {
+	init<S: SequenceType where S.Generator.Element == Element>(_ elements: S) {
+		self.init()
+		var generator = elements.generate()
+		let next: () -> Element? = { generator.next() }
+		for (key, value) in GeneratorOf(next) {
+			updateValue(value, forKey: key)
+		}
+	}
+
+	func filter(includeKeyAndValue: Element -> Bool) -> Dictionary {
+		return Dictionary(Swift.filter(self, includeKeyAndValue))
+	}
 }
 
 

--- a/Tesseract/Graph.swift
+++ b/Tesseract/Graph.swift
@@ -64,6 +64,27 @@ public struct Graph<T> {
 	}
 
 
+	public func reduce<Result>(from: Identifier, _ initial: Result, _ combine: (Result, (Identifier, T)) -> Result) -> Result {
+		return reduce(from, [], initial, combine)
+	}
+
+	public func reduce<Result>(from: Identifier, var _ visited: Set<Identifier>, _ initial: Result, _ combine: (Result, (Identifier, T)) -> Result) -> Result {
+		if visited.contains(from) { return initial }
+		visited.append(from)
+
+		if let node = nodes[from] {
+			let inputs = edges
+				|> (flip(Swift.filter) <| { $0.destination.identifier == from })
+				|> (flip(sorted) <| { $0.source < $1.source })
+				|> (flip(Swift.map) <| { $0.source.identifier })
+			return combine(inputs.reduce(initial) { into, each in
+				self.reduce(each.0, visited, into, combine)
+			}, (from, node))
+		}
+		return initial
+	}
+
+
 	// MARK: Private
 
 	private mutating func sanitize(added: Set<Edge>) {

--- a/Tesseract/Graph.swift
+++ b/Tesseract/Graph.swift
@@ -49,7 +49,7 @@ public struct Graph<T> {
 	}
 
 	
-	// MARK: Higher-order methods.
+	// MARK: Higher-order methods
 
 	public func filter(includeNode: (Identifier, T) -> Bool) -> Graph {
 		return Graph(nodes: nodes.filter(includeNode), edges: edges)

--- a/Tesseract/Graph.swift
+++ b/Tesseract/Graph.swift
@@ -55,6 +55,10 @@ public struct Graph<T> {
 		return Graph(nodes: nodes.filter(includeNode), edges: edges)
 	}
 
+	public func filter(includeEdge: Edge -> Bool) -> Graph {
+		return Graph(nodes: nodes, edges: edges.filter(includeEdge))
+	}
+
 
 	// MARK: Private
 

--- a/Tesseract/Graph.swift
+++ b/Tesseract/Graph.swift
@@ -26,6 +26,7 @@ public struct Graph<T> {
 	public init(nodes: [Identifier: T] = [:], edges: Set<Edge> = []) {
 		self.nodes = nodes
 		self.edges = edges
+		sanitize(edges)
 	}
 
 
@@ -43,12 +44,7 @@ public struct Graph<T> {
 
 	public var edges: Set<Edge> {
 		didSet {
-			let added = edges - oldValue
-			if added.count == 0 { return }
-			let keys = nodes.keys
-			edges -= added.filter {
-				!contains(keys, $0.source.identifier) && !contains(keys, $0.destination.identifier)
-			}
+			sanitize(edges - oldValue)
 		}
 	}
 
@@ -57,6 +53,17 @@ public struct Graph<T> {
 
 	public func filter(includeNode: (Identifier, T) -> Bool) -> Graph {
 		return Graph(nodes: nodes.filter(includeNode), edges: edges)
+	}
+
+
+	// MARK: Private
+
+	private mutating func sanitize(added: Set<Edge>) {
+		if added.count == 0 { return }
+		let keys = nodes.keys
+		edges -= added.filter {
+			!contains(keys, $0.source.identifier) && !contains(keys, $0.destination.identifier)
+		}
 	}
 }
 

--- a/Tesseract/Graph.swift
+++ b/Tesseract/Graph.swift
@@ -59,6 +59,10 @@ public struct Graph<T> {
 		return Graph(nodes: nodes, edges: edges.filter(includeEdge))
 	}
 
+	public func filter(includeNode: (Identifier, T) -> Bool = const(true), includeEdge: Edge -> Bool = const(true)) -> Graph {
+		return Graph(nodes: nodes.filter(includeNode), edges: edges.filter(includeEdge))
+	}
+
 
 	// MARK: Private
 
@@ -75,3 +79,4 @@ public struct Graph<T> {
 // MARK: - Imports
 
 import Set
+import Prelude

--- a/Tesseract/Graph.swift
+++ b/Tesseract/Graph.swift
@@ -61,22 +61,6 @@ public struct Graph<T> {
 }
 
 
-extension Dictionary {
-	init<S: SequenceType where S.Generator.Element == Element>(_ elements: S) {
-		self.init()
-		var generator = elements.generate()
-		let next: () -> Element? = { generator.next() }
-		for (key, value) in GeneratorOf(next) {
-			updateValue(value, forKey: key)
-		}
-	}
-
-	func filter(includeKeyAndValue: Element -> Bool) -> Dictionary {
-		return Dictionary(Swift.filter(self, includeKeyAndValue))
-	}
-}
-
-
 // MARK: - Imports
 
 import Set

--- a/Tesseract/Identifier.swift
+++ b/Tesseract/Identifier.swift
@@ -112,7 +112,7 @@ public func < (left: SourceIdentifier, right: SourceIdentifier) -> Bool {
 }
 
 
-public enum DestinationIdentifier: Hashable, Printable {
+public enum DestinationIdentifier: Comparable, Hashable, Printable {
 	case Output(Int)
 	case Node(NodeIdentifier, Int)
 
@@ -160,6 +160,12 @@ public func == (left: DestinationIdentifier, right: DestinationIdentifier) -> Bo
 	let (leftIdentifier, leftIndex) = left.destructured
 	let (rightIdentifier, rightIndex) = right.destructured
 	return leftIdentifier == rightIdentifier && leftIndex == rightIndex
+}
+
+public func < (left: DestinationIdentifier, right: DestinationIdentifier) -> Bool {
+	let (leftIdentifier, leftIndex) = left.destructured
+	let (rightIdentifier, rightIndex) = right.destructured
+	return  (leftIdentifier == rightIdentifier) ? leftIndex < rightIndex : false
 }
 
 

--- a/Tesseract/Identifier.swift
+++ b/Tesseract/Identifier.swift
@@ -55,7 +55,7 @@ public func == (left: Identifier, right: Identifier) -> Bool {
 
 // MARK: - Component identifiers
 
-public enum SourceIdentifier: Hashable, Printable {
+public enum SourceIdentifier: Comparable, Hashable, Printable {
 	case Input(Int)
 	case Node(NodeIdentifier, Int)
 
@@ -103,6 +103,12 @@ public func == (left: SourceIdentifier, right: SourceIdentifier) -> Bool {
 	let (leftIdentifier, leftIndex) = left.destructured
 	let (rightIdentifier, rightIndex) = right.destructured
 	return leftIdentifier == rightIdentifier && leftIndex == rightIndex
+}
+
+public func < (left: SourceIdentifier, right: SourceIdentifier) -> Bool {
+	let (leftIdentifier, leftIndex) = left.destructured
+	let (rightIdentifier, rightIndex) = right.destructured
+	return (leftIdentifier == rightIdentifier) ? leftIndex < rightIndex : false
 }
 
 

--- a/TesseractTests/GraphTests.swift
+++ b/TesseractTests/GraphTests.swift
@@ -49,5 +49,7 @@ final class GraphTests: XCTestCase {
 			Edge(x, iff.input(2)),
 			Edge(iff.output(0), result)
 		])
+		XCTAssertEqual(abs.nodes.count, 6)
+		XCTAssertEqual(abs.edges.count, 7)
 	}
 }

--- a/TesseractTests/GraphTests.swift
+++ b/TesseractTests/GraphTests.swift
@@ -52,4 +52,17 @@ final class GraphTests: XCTestCase {
 		XCTAssertEqual(abs.nodes.count, 6)
 		XCTAssertEqual(abs.edges.count, 7)
 	}
+
+	func testReductionDoesNotTraverseWithoutEdges() {
+		let graph = Graph(nodes: [ .Output(0): "a", .Node(NodeIdentifier()): "b" ])
+		let result = graph.reduce(.Output(0), "_") { into, each in into + each.1 }
+		XCTAssertEqual(result, "_a")
+	}
+
+	func testReductionTraversesEdges() {
+		let (a, b, c) = (NodeIdentifier(), NodeIdentifier(), NodeIdentifier())
+		let graph = Graph(nodes: [ .Node(a): "a", .Node(b): "b", .Node(c): "c", .Output(0): "!" ], edges: [ Edge(.Node(a, 0), .Output(0)), Edge(.Node(b, 0), .Output(0)), Edge(.Node(c, 0), .Output(0)) ])
+		let result = graph.reduce(.Output(0), "_") { into, each in into + each.1 }
+		XCTAssertEqual(result, "_abc!")
+	}
 }


### PR DESCRIPTION
Higher-order functions over dictionaries, and some higher-order functions over graphs.

This is a fairly minimal spike. It’s hoped that this will enable direct evaluation of graphs.

Fixes #16.